### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This repository contains data and `R` code files from the following analyses of Ebola virus disease (EVD) outbreaks:
 
-1. Althaus CL. (2014) [Estimating the reproduction number of Ebola virus (EVOB) during the 2014 outbreak in West Africa](http://dx.doi.org/10.1371/currents.outbreaks.91afb5e0f279e7f29e7056095255b288). PLoS Curr, 6.
-2. Althaus CL, Low N, Musa EO, Shuaib F, Gsteiger S. (2015) [Ebola virus disease outbreak in Nigeria: Transmission dynamics and rapid control](http://dx.doi.org/10.1016/j.epidem.2015.03.001). Epidemics, 11:80-4.
-3. Althaus CL. (2015) [Rapid drop in the reproduction number during the Ebola outbreak in the Democratic Republic of Congo](https://dx.doi.org/10.7287/peerj.preprints.1041). PeerJ, 3:e1418.
-4. Althaus CL. (2015) [Ebola superspreading](http://dx.doi.org/10.1016/S1473-3099(15)70135-0). Lancet Infect Dis, 15:507-8.
-5. Abbate JL, Murall CL, Richner H, Althaus CL. (2016) [Potential impact of sexual transmission on Ebola virus epidemiology: Sierra Leone as a case study](http://dx.doi.org/10.1371/journal.pntd.0004676). PLOS Negl Trop Dis, 10:e0004676.
+1. Althaus CL. (2014) [Estimating the reproduction number of Ebola virus (EVOB) during the 2014 outbreak in West Africa](https://doi.org/10.1371/currents.outbreaks.91afb5e0f279e7f29e7056095255b288). PLoS Curr, 6.
+2. Althaus CL, Low N, Musa EO, Shuaib F, Gsteiger S. (2015) [Ebola virus disease outbreak in Nigeria: Transmission dynamics and rapid control](https://doi.org/10.1016/j.epidem.2015.03.001). Epidemics, 11:80-4.
+3. Althaus CL. (2015) [Rapid drop in the reproduction number during the Ebola outbreak in the Democratic Republic of Congo](https://doi.org/10.7287/peerj.preprints.1041). PeerJ, 3:e1418.
+4. Althaus CL. (2015) [Ebola superspreading](https://doi.org/10.1016/S1473-3099(15)70135-0). Lancet Infect Dis, 15:507-8.
+5. Abbate JL, Murall CL, Richner H, Althaus CL. (2016) [Potential impact of sexual transmission on Ebola virus epidemiology: Sierra Leone as a case study](https://doi.org/10.1371/journal.pntd.0004676). PLOS Negl Trop Dis, 10:e0004676.
 6. Althaus CL. (2018) [Real-time analysis of the 2018 Ebola outbreak in the Democratic Republic of Congo](https://github.com/calthaus/Ebola/tree/master/DRC%20(GitHub%202018)). GitHub.
 
 [![DOI](https://zenodo.org/badge/38845623.svg)](https://zenodo.org/badge/latestdoi/38845623)

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/Fig2_determ_etaAnalysis.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/Fig2_determ_etaAnalysis.R
@@ -9,7 +9,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/Fig3_determ_alphaAnalysis.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/Fig3_determ_alphaAnalysis.R
@@ -9,7 +9,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/determ_sensitivity.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/determ_sensitivity.R
@@ -8,7 +8,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/parameter_estimation_MLE.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/parameter_estimation_MLE.R
@@ -9,7 +9,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/readme.txt
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/readme.txt
@@ -9,7 +9,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_NoSTI.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_NoSTI.R
@@ -8,7 +8,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_STI_3mo.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_STI_3mo.R
@@ -8,7 +8,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_STI_6mo.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_STI_6mo.R
@@ -8,7 +8,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 

--- a/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_summary_stats.R
+++ b/Sexual transmission (PLOS Negl Trop Dis 2016)/stoch_summary_stats.R
@@ -8,7 +8,7 @@
 #  JL Abbate, C-L Murall, H Richner, CL Althaus                   #
 #  2016 PLoS Neglected Tropical Diseases                          #
 #                                                                 #
-#  PrePrint available bioRxiv http://dx.doi.org/10.1101/031880    #
+#  PrePrint available bioRxiv https://doi.org/10.1101/031880    #
 #  December 11, 2015                                              #        
 ###################################################################
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but since you also refer to Zenodo, which started using `https://doi.org` for its badges as well, I'd like to suggest to hereby update all static DOI links.

Cheers!